### PR TITLE
Fix proto service usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,19 @@ pub mod load {
     tonic::include_proto!("load");
 }
 
+#[derive(Default)]
+struct MyLoadService;
+
+#[tonic::async_trait]
+impl load::load_service_server::LoadService for MyLoadService {
+    async fn set_load(
+        &self,
+        _request: tonic::Request<load::Load>,
+    ) -> Result<tonic::Response<load::Empty>, tonic::Status> {
+        Ok(tonic::Response::new(load::Empty {}))
+    }
+}
+
 #[derive(Parser, Debug)]
 struct Opts {
     #[clap(subcommand)]
@@ -24,16 +37,22 @@ async fn main() -> anyhow::Result<()> {
     match opts.command {
         Command::Server => {
             let addr = "[::1]:50051".parse()?;
-            let server = load::load_server::LoadServer::default();
+            let service = MyLoadService::default();
+            let server = load::load_service_server::LoadServiceServer::new(service);
             tonic::transport::Server::builder()
                 .add_service(server)
                 .serve(addr)
                 .await?;
         }
         Command::Client => {
-            let mut client = load::load_client::LoadClient::connect("http://[::1]:50051").await?;
-            let request = tonic::Request::new(load::LoadRequest {});
-            let response = client.load(request).await?;
+            let mut client =
+                load::load_service_client::LoadServiceClient::connect("http://[::1]:50051")
+                    .await?;
+            let request = tonic::Request::new(load::Load {
+                cpus: 1,
+                time_seconds: 1,
+            });
+            let response = client.set_load(request).await?;
             println!("Response: {:?}", response.into_inner());
         }
     }


### PR DESCRIPTION
## Summary
- implement basic `LoadService` trait
- use correct `LoadServiceServer` and `LoadServiceClient`
- use proto messages and method names that match the proto definition

## Testing
- `cargo check --offline` *(fails: no matching package named `clap` found)*

------
https://chatgpt.com/codex/tasks/task_e_686a53f17eb883258f10b177e0bfb06d