### PR TITLE
Support streaming load progress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tokio = { version = "1.46.0", features = ["full"] }
 tonic = "0.13.1"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tokio-stream = "0.1"
 
 [build-dependencies]
 tonic-build = "0.13.1"

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -6,8 +6,12 @@ message Load {
   int32 cpus = 1;
   int32 time_seconds = 2;
 }
-message Empty {}
+
+message Progress {
+  int32 spent_seconds = 1;
+  int32 total_seconds = 2;
+}
 
 service LoadService {
-  rpc SetLoad(Load) returns (Empty);
+  rpc SetLoad(Load) returns (stream Progress);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use tokio_stream::wrappers::ReceiverStream;
 
 pub mod load {
     tonic::include_proto!("load");
@@ -9,10 +10,12 @@ struct MyLoadService;
 
 #[tonic::async_trait]
 impl load::load_service_server::LoadService for MyLoadService {
+    type SetLoadStream = ReceiverStream<Result<load::Progress, tonic::Status>>;
+
     async fn set_load(
         &self,
         request: tonic::Request<load::Load>,
-    ) -> Result<tonic::Response<load::Empty>, tonic::Status> {
+    ) -> Result<tonic::Response<Self::SetLoadStream>, tonic::Status> {
         tracing::info!("Received load request: {:?}", request);
 
         let load::Load {
@@ -21,10 +24,12 @@ impl load::load_service_server::LoadService for MyLoadService {
         } = request.into_inner();
 
         let cpus = cpus.max(1) as usize;
-        let duration = std::time::Duration::from_secs(time_seconds.max(1) as u64);
+        let total_seconds = time_seconds.max(1);
+        let duration = std::time::Duration::from_secs(total_seconds as u64);
 
         for _ in 0..cpus {
             tokio::task::spawn_blocking({
+                let duration = duration.clone();
                 move || {
                     let end = std::time::Instant::now() + duration;
                     while std::time::Instant::now() < end {
@@ -34,7 +39,26 @@ impl load::load_service_server::LoadService for MyLoadService {
             });
         }
 
-        Ok(tonic::Response::new(load::Empty {}))
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        tokio::spawn(async move {
+            let mut spent = 0;
+            while spent < total_seconds {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                spent = (spent + 5).min(total_seconds);
+                if tx
+                    .send(Ok(load::Progress {
+                        spent_seconds: spent,
+                        total_seconds,
+                    }))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        Ok(tonic::Response::new(ReceiverStream::new(rx)))
     }
 }
 
@@ -81,8 +105,14 @@ async fn main() -> anyhow::Result<()> {
                 cpus: num_cpus.unwrap_or(1),
                 time_seconds: time_seconds.unwrap_or(5),
             });
-            let response = client.set_load(request).await?;
-            println!("Response: {:?}", response.into_inner());
+            let mut stream = client.set_load(request).await?.into_inner();
+            while let Some(progress) = stream.message().await? {
+                println!(
+                    "spent {} of {} seconds",
+                    progress.spent_seconds,
+                    progress.total_seconds
+                );
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
- add `Progress` message and return a stream of progress updates
- stream progress from `SetLoad` RPC every five seconds
- display progress in the client
- depend on `tokio-stream` for server streaming support

## Testing
- `cargo check --locked` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686b64d105d48325b9d4a96aabf8abd8